### PR TITLE
Add simple FastAPI-based Spotify dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# wingtest
+# Spotify Dashboard
+
+This project contains a small FastAPI application that serves a simple
+Spotify analytics dashboard. The data is loaded from `data.json` and
+displayed in the browser using Chart.js.
+
+## Running the server
+
+```bash
+python3 -m uvicorn app.main:app --reload --port 8000
+```
+
+Then open `http://localhost:8000` in your browser.
+
+## Updating data
+
+Edit the `data.json` file with your latest Spotify statistics or automate
+updates using the Spotify API. The dashboard expects the following fields:
+
+- `total_streams_all_time`
+- `total_streams_daily`
+- `monthly_listeners`
+- `global_rank`
+- `fastest_growing_country`
+- `fastest_growing_city`
+- `chart_performance`
+  - `global_rank`
+  - `us_rank`
+  - `south_korea_rank`
+  - `days_on_chart`
+- `top_countries` (array with `name` and `streams`)
+- `top_cities` (array with `name` and `streams`)
+- `milestone`
+
+Feel free to adapt the frontend to your needs or connect the API to a
+real database for historical tracking.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.responses import FileResponse
+import json
+from pathlib import Path
+
+app = FastAPI()
+
+# Serve static files
+app.mount("/", StaticFiles(directory="static", html=True), name="static")
+
+DATA_FILE = Path(__file__).resolve().parent.parent / "data.json"
+
+@app.get("/api/data")
+def get_data():
+    if DATA_FILE.exists():
+        with open(DATA_FILE) as f:
+            return json.load(f)
+    return {}

--- a/data.json
+++ b/data.json
@@ -1,0 +1,29 @@
+{
+  "total_streams_all_time": 300000000,
+  "total_streams_daily": 123456,
+  "monthly_listeners": 12345678,
+  "global_rank": 10,
+  "fastest_growing_country": "South Korea",
+  "fastest_growing_city": "Seoul",
+  "chart_performance": {
+    "global_rank": 10,
+    "us_rank": 20,
+    "south_korea_rank": 1,
+    "days_on_chart": 45
+  },
+  "top_countries": [
+    {"name": "South Korea", "streams": 12345678},
+    {"name": "United States", "streams": 9876543},
+    {"name": "Japan", "streams": 8765432},
+    {"name": "Indonesia", "streams": 7654321},
+    {"name": "Brazil", "streams": 6543210}
+  ],
+  "top_cities": [
+    {"name": "Seoul", "streams": 4321098},
+    {"name": "Tokyo", "streams": 3210987},
+    {"name": "Los Angeles", "streams": 2109876},
+    {"name": "New York", "streams": 1987654},
+    {"name": "Jakarta", "streams": 1876543}
+  ],
+  "milestone": "Next goal: 500M Like Crazy streams"
+}

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Spotify Dashboard</title>
+  <link rel="stylesheet" href="style.css" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+  <div class="container">
+    <h1>Spotify Summary</h1>
+    <div id="summary">
+      <div class="metric" id="total-streams"></div>
+      <div class="metric" id="monthly-listeners"></div>
+      <div class="metric" id="fastest-growing"></div>
+    </div>
+
+    <h2>Chart Performance</h2>
+    <div id="chart-performance">
+      <canvas id="rank-chart" width="400" height="200"></canvas>
+      <div class="metric" id="days-on-chart"></div>
+    </div>
+
+    <h2>Country & City Streaming Insights</h2>
+    <div class="insights">
+      <canvas id="country-chart" width="400" height="200"></canvas>
+      <canvas id="city-chart" width="400" height="200"></canvas>
+    </div>
+
+    <h2>Milestones & Goals</h2>
+    <div id="milestone"></div>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,56 @@
+async function loadData() {
+  const res = await fetch('/api/data');
+  const data = await res.json();
+
+  document.getElementById('total-streams').textContent = `🎧 Total Streams: ${data.total_streams_all_time.toLocaleString()} (All-Time) / ${data.total_streams_daily.toLocaleString()} today`;
+  document.getElementById('monthly-listeners').textContent = `🌍 Monthly Listeners: ${data.monthly_listeners.toLocaleString()} (Global Rank ${data.global_rank})`;
+  document.getElementById('fastest-growing').textContent = `🚀 Fastest Growing: ${data.fastest_growing_country} - ${data.fastest_growing_city}`;
+
+  document.getElementById('days-on-chart').textContent = `📆 Days on Chart: ${data.chart_performance.days_on_chart}`;
+
+  renderRankChart(data.chart_performance);
+  renderBarChart('country-chart', data.top_countries);
+  renderBarChart('city-chart', data.top_cities);
+
+  document.getElementById('milestone').textContent = data.milestone;
+}
+
+function renderRankChart(perf) {
+  const ctx = document.getElementById('rank-chart');
+  new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: ['Global', 'US', 'South Korea'],
+      datasets: [{
+        label: 'Rank',
+        data: [perf.global_rank, perf.us_rank, perf.south_korea_rank],
+        backgroundColor: ['#4e79a7', '#f28e2b', '#e15759']
+      }]
+    },
+    options: {
+      scales: {
+        y: { reverse: true, beginAtZero: false }
+      }
+    }
+  });
+}
+
+function renderBarChart(id, items) {
+  const ctx = document.getElementById(id);
+  new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: items.map(i => i.name),
+      datasets: [{
+        label: 'Streams',
+        data: items.map(i => i.streams),
+        backgroundColor: '#4e79a7'
+      }]
+    },
+    options: {
+      plugins: { legend: { display: false } }
+    }
+  });
+}
+
+loadData();

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,25 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background: #f4f4f4;
+}
+
+.container {
+  max-width: 900px;
+  margin: 20px auto;
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0,0,0,0.1);
+}
+
+.metric {
+  margin-bottom: 10px;
+  font-size: 1.2em;
+}
+
+.insights {
+  display: flex;
+  gap: 20px;
+}


### PR DESCRIPTION
## Summary
- create FastAPI server in `app/main.py`
- provide sample data in `data.json`
- add static files for dashboard (HTML, CSS, JS)
- update README with running instructions

## Testing
- `python3 -m py_compile app/main.py`
- `python3 -m uvicorn app.main:app --port 8001 --reload` (started and stopped)