### PR TITLE
Add DataWeave example

### DIFF
--- a/order_transform.dwl
+++ b/order_transform.dwl
@@ -1,0 +1,27 @@
+%dw 2.0
+output application/json
+var order = payload.order
+---
+{
+  product: {
+    price: order.product.price as Number,
+    model: order.product.model
+  },
+  item_amount: order.item_amount as Number,
+  payment: {
+    'payment-type': order.payment.'payment-type',
+    currency: order.payment.currency,
+    installments: order.payment.installments as Number
+  },
+  buyer: {
+    email: order.buyer.email,
+    name: order.buyer.name,
+    address: order.buyer.address,
+    city: order.buyer.city,
+    state: order.buyer.state,
+    postCode: order.buyer.postCode,
+    nationality: order.buyer.nationality
+  },
+  shop: order.shop,
+  salesperson: order.salesperson
+}


### PR DESCRIPTION
## Summary
- add an example DataWeave script that converts the provided XML structure into a JSON object

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_685d78a9eebc832b804f7711146524b5